### PR TITLE
Add international resources section (English-language Palworld guide hub)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,13 @@ https://github.com/GalileoFe/PalWorld-Save-Movement-Complete-Tutorio
 
 
 
+
+
+### 国际社区资源 / International Resources
+
+- [Palworld Guides](https://palworldguides.xyz/) — Palworld tier lists, base builds, Pal breeding chains, and boss strategies.
+- [Awesome Palworld (EN)](https://github.com/zxml7777777/awesome-palworld) — Curated list of Palworld resources in English.
+
 # Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=PlexPt/awesome-palworld&type=Date)](https://star-history.com/#PlexPt/awesome-palworld&Date)


### PR DESCRIPTION
Hi PlexPt — thanks for maintaining this excellent Palworld guide list!

This PR proposes adding a small `国际社区资源 / International Resources` section for English-speaking Palworld players, containing:

- [Palworld Guides](https://palworldguides.xyz/) — English-language tier lists, base builds, breeding chains, boss strategies.
- [Awesome Palworld (EN)](https://github.com/zxml7777777/awesome-palworld) — sister awesome-list in English.

The section is inserted just before `# Star History` so existing Chinese sections are untouched. Happy to adjust wording, drop the awesome-list entry, or move the section elsewhere — whatever fits your preference.