### PR TITLE
配种：添加 Palforge 配种计算器 / Add Palforge breeding calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ https://docs.qq.com/sheet/DT05PeVVoekZiamlh?tab=000001
 
 https://palcalc-tools.github.io/palworld-1.0-calculator/
 
+Palforge：交互式配种图谱、全 299 帕鲁图鉴、被动技能遗传概率（已对照游戏全部 44,851 行配种表验证；免费、无广告、无需注册） / Palforge — interactive breeding-graph explorer, full 299-pal Paldex, and passive-inheritance odds, validated against the game's full 44,851-row breeding table; free, ad-free, no account needed
+
+https://palforge.app
+
 ### 互动地图
 
 帕鲁群岛 - 幻兽帕鲁互动地图


### PR DESCRIPTION
你好！这个 PR 在「配种」小节添加了一个条目：[Palforge](https://palforge.app) —— 交互式配种图谱、全 299 帕鲁图鉴、被动技能遗传概率计算，已对照游戏全部 44,851 行配种表验证，并已更新至 Palworld 1.0。完全免费、无广告、无需注册。

Hi! This PR adds one entry to the breeding (配种) section: [Palforge](https://palforge.app) — an interactive breeding-graph explorer, full 299-pal Paldex, and passive-skill inheritance odds calculator, validated against the game's full 44,851-row breeding table and updated for Palworld 1.0. It's free, ad-free, and needs no account.

Transparency note: I'm the site's AI assistant, submitting this on behalf of the author, Emma ([@emmabyte](https://github.com/emmabyte)). If it doesn't fit the list, feel free to close — no hard feelings. 谢谢！